### PR TITLE
Typos

### DIFF
--- a/query_SDG11.xml
+++ b/query_SDG11.xml
@@ -102,10 +102,10 @@
 				( "sustainab*"  OR  "inclusi*" )  W/3  ( "urbanisation"  OR  "urbanization"  OR  "settlement*"  OR  "city"  OR  "cities" )  
                 </aqd:query-line>
                  <aqd:query-line field="TITLE-ABS-KEY">
-				 ( ( "land"  W/3  "consumption" )  AND  ( "population"  W/3  "growth" ) )  
+				 ( ( "land"  W/3  "consumption" )  AND  ( "population"  W/3  "growth" ) )
                 </aqd:query-line>
                  <aqd:query-line field="TITLE-ABS-KEY">
-				 ( "urban"  OR  "city" )  W/3  ( "planning"  OR  "management" )  W/3  ( "participat*" )  
+				 ( "urban"  OR  "city" )  W/3  ( "planning"  OR  "management" )  W/3  ( "participat*" )
                 </aqd:query-line>
 				</aqd:query-lines>
         </aqd:query-definition>

--- a/query_SDG11.xml
+++ b/query_SDG11.xml
@@ -174,7 +174,7 @@
             </aqd:subquery-descriptions>
             <aqd:query-lines>
                 <aqd:query-line field="TITLE-ABS-KEY">
-				( "city"  OR  "cities"  OR  "urban"  OR  "municipalit*" )  W/3 (( "air quality" OR "smog") OR ( "waste management" ) OR ( "solid waste " ) OR ( "PM10" OR   "PM2.5" )) 
+				( "city"  OR  "cities"  OR  "urban"  OR  "municipalit*" )  W/3 (( "air quality" OR "smog") OR ( "waste management" ) OR ( "solid waste" ) OR ( "PM10" OR   "PM2.5" ))
                 </aqd:query-line>
             </aqd:query-lines>
         </aqd:query-definition>

--- a/query_SDG2.xml
+++ b/query_SDG2.xml
@@ -55,7 +55,7 @@
                 <aqd:query-line field="TITLE-ABS-KEY">( "access") W/3 ("food*" OR "nutrition*") W/3 ("poor" OR "child*" OR "infant*")
 				</aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">( "prevalen*" OR "hunger*" OR "famine" ) W/3
-				("food security" OR "food insecurity" OR "food deprivation" OR "malnutrition*" OR "undernutrion*" OR "malnourish*" OR "undernourish*")
+				("food security" OR "food insecurity" OR "food deprivation" OR "malnutrition*" OR "undernutrition*" OR "malnourish*" OR "undernourish*")
                 </aqd:query-line>
             </aqd:query-lines>
         </aqd:query-definition>
@@ -105,7 +105,7 @@
                 </aqd:subquery-description>
             </aqd:subquery-descriptions>
             <aqd:query-lines>
-                 <aqd:query-line field="TITLE-ABS-KEY">("agriculture*" OR "food*") W/3 ("producti*") AND ("scale" OR "smallscale")
+                 <aqd:query-line field="TITLE-ABS-KEY">("agriculture*" OR "food*") W/3 ("producti*") AND ("scale" OR "small-scale")
 				</aqd:query-line>
 				<aqd:query-line field="TITLE-ABS-KEY">("agriculture*" OR "food*") W/3 ("sustainab*") W/3 ("intensificat*")
 				</aqd:query-line>

--- a/query_SDG3.xml
+++ b/query_SDG3.xml
@@ -255,7 +255,7 @@
                 ("family planning" OR "unintended pregnanc*" OR "unwanted pregnanc*" OR "unintended motherhood")
                 </aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ("adolescen*" OR "teen*") W/3 ("birth rate" OR "pregnan" OR "mother*")
+                ("adolescen*" OR "teen*") W/3 ("birth rate" OR "pregnan*" OR "mother*")
                 </aqd:query-line>
 				</aqd:query-lines>
         </aqd:query-definition>

--- a/query_SDG4.xml
+++ b/query_SDG4.xml
@@ -84,7 +84,7 @@
             <aqd:query-lines>
                 <aqd:query-line field="TITLE-ABS-KEY">
                     ( "Quality" OR "equitabl*" OR "free" OR "access" OR "affordab*") W/3
-                    ( "preschool" OR "pre-school" OR" pre-primary education" OR "pre-primary school" OR "preprimary education" OR "preprimary school")
+                    ( "preschool" OR "pre-school" OR "pre-primary education" OR "pre-primary school" OR "preprimary education" OR "preprimary school")
                 </aqd:query-line>
             </aqd:query-lines>
         </aqd:query-definition>

--- a/query_SDG5.xml
+++ b/query_SDG5.xml
@@ -187,7 +187,7 @@
 				</aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">( "Access" )  AND  ( "Sexual health care"  OR  "Sexual healthcare"  OR  "Reproductive health care"  OR  "Reproductive healthcare" )
 				</aqd:query-line>
-				<aqd:query-line field="TITLE-ABS-KEY">( ( "own"  OR  "informed" )  W/3  ( "decision" )  W/3  ( "sexual"  OR  "contracepti*"  OR  "reproducti*"  OR  "family planning"  OR  "parentiong plan*"  OR  "abortion" ) )  
+				<aqd:query-line field="TITLE-ABS-KEY">( ( "own"  OR  "informed" )  W/3  ( "decision" )  W/3  ( "sexual"  OR  "contracepti*"  OR  "reproducti*"  OR  "family planning"  OR  "parenting plan*"  OR  "abortion" ) )
 				</aqd:query-line>
 				<aqd:query-line field="TITLE-ABS-KEY">( "Access" )  AND  ( "Sexual information"  OR  "Sexual education"  OR  "Reproductive information"  OR  "Reproductive education" )
 				</aqd:query-line>

--- a/query_SDG7.xml
+++ b/query_SDG7.xml
@@ -71,13 +71,13 @@
             </aqd:subquery-descriptions>
             <aqd:query-lines>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ( "share"  OR  "increas*"  OR  "promot" )  W/3  ( ( "renewable"  OR  "alternative"  OR  "clean" )  W/3  ( "energy"  OR  "fuel" ) )  
+                ( "share"  OR  "increas*"  OR  "promot*" )  W/3  ( ( "renewable"  OR  "alternative"  OR  "clean" )  W/3  ( "energy"  OR  "fuel" ) )
 				</aqd:query-line>
                  <aqd:query-line field="TITLE-ABS-KEY">
-                ( "share"  OR  "increas*"  OR  "promot" )  W/3  ( ( "energy" )  W/3  ( "conversion"  OR  "transition" ) )  
+                ( "share"  OR  "increas*"  OR  "promot*" )  W/3  ( ( "energy" )  W/3  ( "conversion"  OR  "transition" ) )
 				</aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ( "share"  OR  "increas*"  OR  "promot" )  W/3  
+                ( "share"  OR  "increas*"  OR  "promot*" )  W/3
 				( "Biofuel*"  OR  "Biogas*"  OR  "Heat pump*"  OR  "Hybrid power"  OR  "Solar energy"  OR  "Solar power"  OR  "Wind energy"  OR  "Wind farm*"  
 				OR  "Wind power"  OR  "Wind turbine*" )  
 				</aqd:query-line>

--- a/query_SDG8.xml
+++ b/query_SDG8.xml
@@ -221,7 +221,7 @@
             </aqd:subquery-descriptions>
             <aqd:query-lines>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                 ( "force* labo*" )  OR  ( "modern slavery" )  OR  ( "human* traffic* " )  OR  ( "child* labo*" )  
+                 ( "force* labo*" )  OR  ( "modern slavery" )  OR  ( "human* traffic*" )  OR  ( "child* labo*" )
 				 OR  ( "child* slavery" )  OR  ( "child* traffick*" )  OR  ( "child* work*" )  
                 </aqd:query-line>
             </aqd:query-lines>

--- a/query_SDG9.xml
+++ b/query_SDG9.xml
@@ -54,7 +54,7 @@
                  ( "quality"  OR  "reliab*"  OR  "sustainab*"  OR  "resilient" )  W/3  ( "infrastructure" )
                 </aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ( "economic development"  OR  "human well-being" )  AND  ( afford*  OR  equitable )
+                ( "economic development"  OR  "human well-being" )  AND  ( "afford*"  OR  "equitable" )
                  </aqd:query-line>
 				 <aqd:query-line field="TITLE-ABS-KEY">
                 ( "rural"  W/3  "population*"  W/3  "road*" )


### PR DESCRIPTION
I believe I found a few more typos. Should be self-explanatory, except perhaps the change from "smallscale" to "small-scale": the latter is used in several other places so I figured it would be good to be consistent.