### PR TITLE
explicit parantheses added

### DIFF
--- a/query_SDG15.xml
+++ b/query_SDG15.xml
@@ -110,7 +110,7 @@
                  ( "restor*" )  W/3  ( "degraded land*"  OR  "degraded dryland*"  OR  "degraded soil*" )    
                 </aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ( "proportion*"  OR  "percentage" )  AND  ( "degraded" )  W/3  ( "land*"  OR  "dryland*"  OR  "soil*" ) 
+                ( "proportion*"  OR  "percentage" )  AND  (( "degraded" )  W/3  ( "land*"  OR  "dryland*"  OR  "soil*" ))
                 </aqd:query-line>
 				</aqd:query-lines>
         </aqd:query-definition>

--- a/query_SDG16.xml
+++ b/query_SDG16.xml
@@ -104,7 +104,7 @@
                 ( ( "end"  OR  "ending"  OR  "reduc*" )  W/3  ( "abus*"  OR  "exploit*"  OR  "traffick*"  OR  "violen*"  OR  "tortur*"  OR  "neglect*" )  W/3  ( "child*" ) )  
 				</aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
-                ( ( "caregiver*" )  AND  ( "abus*"  OR  "exploit*"  OR  "traffick*"  OR  "violen*"  OR  "tortur*"  OR  "neglect*" )  W/3  ( "child*" ) )   
+                ( ( "caregiver*" )  AND  (( "abus*"  OR  "exploit*"  OR  "traffick*"  OR  "violen*"  OR  "tortur*"  OR  "neglect*" )  W/3  ( "child*" )) )  
                 </aqd:query-line>
                 <aqd:query-line field="TITLE-ABS-KEY">
                 ( ( "victim*" )  AND  ( "human traffick*" ) )  

--- a/query_SDG17.xml
+++ b/query_SDG17.xml
@@ -239,7 +239,7 @@
             </aqd:subquery-descriptions>
             <aqd:query-lines>
                 <aqd:query-line field="TITLE-ABS-KEY">
-				 ( "develop* countr*"  OR  "least developed countr*"  OR  "small island*" )  AND  ( "capacity*" )  W/3  ( "science"  OR  "technology"  OR  "innovation" )
+				 ( "develop* countr*"  OR  "least developed countr*"  OR  "small island*" )  AND  (( "capacity*" )  W/3  ( "science"  OR  "technology"  OR  "innovation" ))
 				</aqd:query-line> 
                 <aqd:query-line field="TITLE-ABS-KEY">
 				 ( ( "subscription*" )  OR  ( ( "proportion" )  W/3  ( "population" ) ) )  AND  ( "internet*" )


### PR DESCRIPTION
I've received syntax errors when running the current queries (3 instances).
It appears to be because of an proximity operator following an AND which I now fixed by introducing parantheses.